### PR TITLE
Fix: Adjust keyboard layout and styling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,10 @@
 import Image from "next/image";
+import { Keyboard } from "@/features/keyboard/components/keyboard";
 
 export default function Home() {
   return (
-    <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20">
-      <main className="row-start-2 flex flex-col items-center gap-[32px] sm:items-start">
+    <div className="flex flex-col min-h-screen font-[family-name:var(--font-geist-sans)] p-8 pb-0 sm:p-20 sm:pb-0">
+      <main className="flex-grow flex flex-col items-center gap-[32px] sm:items-start">
         <Image
           className="dark:invert"
           src="/next.svg"
@@ -49,7 +50,7 @@ export default function Home() {
           </a>
         </div>
       </main>
-      <footer className="row-start-3 flex flex-wrap items-center justify-center gap-[24px]">
+      <footer className="flex flex-wrap items-center justify-center gap-[24px] mb-8">
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
@@ -78,6 +79,7 @@ export default function Home() {
           Go to nextjs.org →
         </a>
       </footer>
+      <Keyboard />
     </div>
   );
 }

--- a/src/features/keyboard/components/key.test.tsx
+++ b/src/features/keyboard/components/key.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { Key } from "./key";
+import { PITCHES } from "../pitches";
+
+describe("Key component", () => {
+  it("renders white keys with only vertical borders", () => {
+    const whitePitch = PITCHES.find(p => !p.includes("#"));
+    if (!whitePitch) throw new Error("No white pitch found for testing");
+
+    render(<Key pitch={whitePitch} />);
+    const keyElement = screen.getByRole("button");
+
+    // Check for presence of side borders
+    expect(keyElement).toHaveClass("border-x");
+    expect(keyElement).toHaveClass("border-black");
+
+    // Check for absence of top, bottom, or general border class (unless border-x implies border)
+    // Given cn behavior and Tailwind, 'border-x' should not automatically imply 'border'
+    // and should not have top/bottom specific classes.
+    expect(keyElement).not.toHaveClass("border-t");
+    expect(keyElement).not.toHaveClass("border-b");
+    expect(keyElement).not.toHaveClass("border-y");
+
+    // A key with only `border-x` should not have the generic `border` class.
+    // However, this depends on how `cn` resolves conflicts if `border-black` is somehow tied to `border`.
+    // The most straightforward reading is that `border-x` and `border` are distinct.
+    // If `border-black` requires `border`, this test might be too strict.
+    // For now, let's assume `border-x` is exclusive of `border`.
+    // The black key class explicitly adds `border`, so this distinction is important.
+    const classList = keyElement.className.split(" ");
+    expect(classList).not.toContain("border"); // Check that the single word "border" is not a class
+  });
+
+  it("renders black keys with all borders", () => {
+    const blackPitch = PITCHES.find(p => p.includes("#"));
+    if (!blackPitch) throw new Error("No black pitch found for testing");
+
+    render(<Key pitch={blackPitch} />);
+    const keyElement = screen.getByRole("button");
+
+    // Black keys should have the full border due to the conditional class
+    // "... border border-black" which should override/merge with "border-x border-black"
+    expect(keyElement).toHaveClass("border");
+    expect(keyElement).toHaveClass("border-black");
+
+    // It might also have border-x from the base class, which is fine as long as 'border' takes precedence visually.
+    // We don't need to assert the absence of border-x, -t, -b, -y if 'border' is present.
+  });
+
+  it("calls onPress when a key is pressed", () => {
+    const mockOnPress = vi.fn();
+    const testPitch = PITCHES[0];
+    render(<Key pitch={testPitch} onPress={mockOnPress} />);
+    const keyElement = screen.getByRole("button");
+
+    // Simulate a pointer down event
+    keyElement.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+    expect(mockOnPress).toHaveBeenCalledWith(testPitch);
+  });
+});

--- a/src/features/keyboard/components/key.tsx
+++ b/src/features/keyboard/components/key.tsx
@@ -12,8 +12,8 @@ export function Key({ pitch, onPress }: KeyProps) {
       type="button"
       data-pitch={pitch}
       className={cn(
-        "h-24 w-8 border border-black active:translate-y-0.5",
-        pitch.includes("#") && "-mx-2 z-10 h-16 w-6 bg-black text-white",
+        "h-24 w-8 border-x border-black active:translate-y-0.5",
+        pitch.includes("#") && "-mx-2 z-10 h-16 w-6 bg-black text-white border border-black",
       )}
       onPointerDown={() => onPress?.(pitch)}
     >

--- a/src/features/keyboard/components/keyboard.test.tsx
+++ b/src/features/keyboard/components/keyboard.test.tsx
@@ -3,10 +3,18 @@ import { describe, expect, it, vi } from "vitest";
 import { Keyboard } from "./keyboard";
 
 describe("Keyboard", () => {
+  it("renders correctly and displays keys", () => {
+    render(<Keyboard />);
+    const keys = screen.getAllByRole("button");
+    expect(keys.length).toBeGreaterThan(0); // Checks that PITCHES are rendered
+  });
+
   it("calls onPress with pitch", () => {
     const spy = vi.fn();
     render(<Keyboard onPress={spy} />);
-    fireEvent.pointerDown(screen.getAllByText("ド")[0]);
+    // This test assumes C3 is the first key with label "ド"
+    // and that PITCHES includes C3.
+    fireEvent.pointerDown(screen.getAllByText("ド")[0]); 
     expect(spy).toHaveBeenCalledWith("C3");
   });
 });


### PR DESCRIPTION
This commit addresses the following issues:
1. Removes the visual gap between white keys on the keyboard by modifying border styles. White keys now only have vertical (left and right) borders. Black keys retain their full borders.
2. Relocates the keyboard to the bottom of the screen for improved usability on mobile and tablet devices. The page layout was changed to a flex column, with the keyboard anchored at the bottom.
3. Adjusts overall screen padding to ensure the keyboard sits flush at the bottom of the viewport, while other elements like the footer and main content maintain appropriate spacing.

Changes include:
- Modified `src/features/keyboard/components/key.tsx` for key styling.
- Modified `src/app/page.tsx` for layout and keyboard placement.
- Added tests in `src/features/keyboard/components/key.test.tsx` to verify key border styling.
- Updated tests in `src/features/keyboard/components/keyboard.test.tsx`.