### PR TITLE
Fix: Correct final note duration in do_re_mi.json

### DIFF
--- a/song_analysis_report.md
+++ b/song_analysis_report.md
@@ -1,0 +1,199 @@
+Song Analysis Report:
+
+--- Song: akatonbo (赤とんぼ) ---
+  Length: 44 notes, Total Duration: 60.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to A4 (9)
+    Unique Pitches: A4, C4, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 85, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (60.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: alps_ichimanjaku (アルプス一万尺) ---
+  Length: 34 notes, Total Duration: 52.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to A4 (9)
+    Unique Pitches: A4, C4, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 120, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (52.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: butterfly (ちょうちょう) ---
+  Length: 32 notes, Total Duration: 39.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to G4 (7)
+    Unique Pitches: C4, D4, E4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 90, Time Signature: [3, 4]
+    Rhythmic Issues:
+      - Total song duration (39.0) aligns with measure length (3). (No issue, this is good)
+
+--- Song: do_re_mi (ドレミの歌) ---
+  Length: 33 notes, Total Duration: 35.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to C5 (12)
+    Unique Pitches: A4, B4, C4, C5, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 90, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (35.0) does not align with measure length (4).
+      - Last phrase duration (3.0) does not make a full measure of 4.0.
+
+--- Song: frog_chorus (かえるの合唱) ---
+  Length: 37 notes, Total Duration: 44.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to F4 (5)
+    Unique Pitches: C4, D4, E4, F4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 100, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (44.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: furusato (ふるさと) ---
+  Length: 30 notes, Total Duration: 68.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to C5 (12)
+    Unique Pitches: A4, C4, C5, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 85, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (68.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: happy_birthday (ハッピーバースデー) ---
+  Length: 28 notes, Total Duration: 42.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to C5 (12)
+    Unique Pitches: A4, Bb4, C4, C5, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): Bb4. (Song is likely F Major, where Bb is diatonic. If F Major assumed, no issues.)
+  Rhythmic Analysis:
+    BPM: 80, Time Signature: [3, 4]
+    Rhythmic Issues:
+      - Total song duration (42.0) aligns with measure length (3). (No issue, this is good)
+      - Contains 0.5 durations (eighth notes), which are acceptable.
+
+--- Song: inu_no_omawarisan (犬のおまわりさん) ---
+  Length: 58 notes, Total Duration: 68.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to A4 (9)
+    Unique Pitches: A4, C4, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 110, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (68.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: mary_had_a_little_lamb (メリーさんのひつじ) ---
+  Length: 33 notes, Total Duration: 36.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: B3 (-1) to D4 (2)
+    Unique Pitches: B3, C4, D4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major, B3 is part of C scale)
+  Rhythmic Analysis:
+    BPM: 100, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (36.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: ookina_kuri_no_ki (大きな栗の木の下で) ---
+  Length: 50 notes, Total Duration: 64.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to A4 (9)
+    Unique Pitches: A4, C4, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 100, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (64.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: sakura (さくら) ---
+  Length: 39 notes, Total Duration: 48.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: E4 (4) to C5 (12)
+    Unique Pitches: A4, B4, C5, E4, F#4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): F#4. (Song is likely in a Japanese scale like Hirajoshi or relative to E minor/G major where F# is diatonic. If E minor/G major assumed, no issues with F#4.)
+  Rhythmic Analysis:
+    BPM: 90, Time Signature: "4/4" (treated as [4,4])
+    Rhythmic Issues:
+      - Total song duration (48.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: twinkle_twinkle (きらきら星) ---
+  Length: 42 notes, Total Duration: 48.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to A4 (9)
+    Unique Pitches: A4, C4, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 100, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (48.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: usagi_to_kame (うさぎとかめ) ---
+  Length: 54 notes, Total Duration: 64.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to C5 (12)
+    Unique Pitches: A4, B4, C4, C5, D4, E4, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major)
+  Rhythmic Analysis:
+    BPM: 100, Time Signature: [4, 4]
+    Rhythmic Issues:
+      - Total song duration (64.0) aligns with measure length (4). (No issue, this is good)
+
+--- Song: zou_san (ぞうさん) ---
+  Length: 52 notes, Total Duration: 60.0
+  Length Criteria: PASS
+  Melodic Analysis:
+    Pitch Range: C4 (0) to D5 (14)
+    Unique Pitches: A4, C4, C5, D4, D5, F4, G4
+    Melodic Issues:
+      - Potential out-of-key notes (assuming C major/relative scale): None (all fit C major or F major context - song is often in F)
+      - Large interval: A4 to D5 (5 semitones, not >12, this is fine)
+      - Large interval: A4 to D5 (again, fine)
+      - Note: The song is often considered in F major. If F major is assumed (F,G,A,Bb,C,D,E), then all notes {C4,D4,F4,G4,A4,C5,D5} are diatonic.
+  Rhythmic Analysis:
+    BPM: 90, Time Signature: [3, 4]
+    Rhythmic Issues:
+      - Total song duration (60.0) aligns with measure length (3). (No issue, this is good)
+
+--- Summary of Songs with Potential Issues ---
+- do_re_mi (Rhythmic: Total duration/last phrase alignment)
+- happy_birthday (Melodic: Bb4 if strictly Cmaj assumed, but fine in Fmaj)
+- sakura (Melodic: F#4 if strictly Cmaj assumed, but fine in context of its scale)
+
+Note on "Out-of-key" analysis: The default assumption was C major. Songs like "happy_birthday" (F major) and "sakura" (Japanese scale / E minor variant) have notes that are "out-of-key" for C major but are correct for their actual tonalities. The report reflects this.
+Note on "Phrase Alignment": The check for total song duration aligning with the measure signature is a basic heuristic. More nuanced phrase analysis was not performed. "do_re_mi" is the only one flagged by this simple check.
+No songs had intervals > 1 octave or successive large leaps in the same direction.
+No songs had durations < 0.5 or unusually long durations beyond the examples discussed.
+All songs meet the basic length criteria.

--- a/src/songs/do_re_mi.json
+++ b/src/songs/do_re_mi.json
@@ -169,7 +169,7 @@
     },
     {
       "pitch": "G4",
-      "duration": 1,
+      "duration": 2,
       "lyric": "ー"
     }
   ]


### PR DESCRIPTION
The total duration of notes in src/songs/do_re_mi.json was 35 beats, which is one beat short of a complete measure in its 4/4 time signature.

This change extends the duration of the final note (G4, lyric "ー") from 1 to 2 beats. This makes the total duration 36 beats, ensuring the song concludes on a complete final measure.

Analysis of other song files found no other structural issues regarding length, melody, or rhythm requiring correction.