### PR TITLE
feat: Implement responsive layout for song playback screen

### DIFF
--- a/src/app/song/[songId]/page.tsx
+++ b/src/app/song/[songId]/page.tsx
@@ -12,7 +12,11 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
-export default function SongPage() {
+type SongPageProps = {
+  layoutMode?: 'horizontal' | 'vertical';
+};
+
+export default function SongPage({ layoutMode }: SongPageProps) {
   const params = useParams();
   const songId = params.songId as SongId;
 
@@ -103,40 +107,45 @@ export default function SongPage() {
         </div>
       </header>
 
-      <div className="flex flex-1 flex-col p-4 pb-32">
-        <div className="flex flex-1 flex-col items-center justify-center">
-          <div className="w-full max-w-4xl">
-            <div className="space-y-8 text-center">
-              <div className="rounded-lg bg-gray-100 p-2 md:p-4">
-                <ScrollScore song={song} currentIndex={currentIndex} />
-              </div>
-              <div>
-                {isCompleted ? (
-                  <div className="space-y-4">
-                    <div className="font-bold text-green-600 text-xl md:text-2xl">
-                      🎉 かんせい！
+      {/* New main content container */}
+      <div className={`flex flex-1 ${mainContentFlexDirection}`}>
+        {/* Score Section */}
+        <div className={scoreSectionClasses}>
+          <div className="flex h-full flex-col items-center justify-center">
+            <div className="w-full max-w-4xl">
+              <div className="space-y-8 text-center">
+                <div className="rounded-lg bg-gray-100 p-2 md:p-4">
+                  <ScrollScore song={song} currentIndex={currentIndex} />
+                </div>
+                <div>
+                  {isCompleted ? (
+                    <div className="space-y-4">
+                      <div className="font-bold text-green-600 text-xl md:text-2xl">
+                        🎉 かんせい！
+                      </div>
+                      <button
+                        type="button"
+                        onClick={handleReset}
+                        className="rounded-lg bg-blue-500 px-6 py-2 text-white hover:bg-blue-600"
+                      >
+                        もう一度
+                      </button>
                     </div>
-                    <button
-                      type="button"
-                      onClick={handleReset}
-                      className="rounded-lg bg-blue-500 px-6 py-2 text-white hover:bg-blue-600"
-                    >
-                      もう一度
-                    </button>
-                  </div>
-                ) : null}
+                  ) : null}
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div className="fixed right-0 bottom-0 left-0 h-1/3 border-gray-200 border-t bg-white shadow-lg md:h-1/3">
-        <div className="flex h-full justify-center overflow-x-auto">
-          <Keyboard
-            highlightedPitch={playController?.getCurrentNote()?.pitch}
-            onPress={handleKeyPress}
-          />
+        {/* Keyboard Section */}
+        <div className={keyboardSectionClasses}>
+          <div className="flex h-full justify-center overflow-x-auto">
+            <Keyboard
+              highlightedPitch={playController?.getCurrentNote()?.pitch}
+              onPress={handleKeyPress}
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This commit introduces a responsive layout for the song playback page (`src/app/song/[songId]/page.tsx`).

Key changes:
- The layout is now horizontal by default for screen widths less than the Tailwind `sm` breakpoint (640px), with the score and keyboard displayed side-by-side.
- For screen widths greater than or equal to the `sm` breakpoint, the layout switches to a vertical stack, with the score appearing above the keyboard.
- This is achieved by restructuring the JSX and applying appropriate Tailwind CSS classes (e.g., `flex-row sm:flex-col` for the main content area, and responsive width/height/border classes for child sections).

Extensibility:
- An optional `layoutMode` prop (`'horizontal' | 'vertical'`) has been added to the `SongPage` component.
- This prop allows programmatically forcing either a horizontal or vertical layout, overriding the default responsive behavior. This is intended to facilitate future tasks related to layout switching.
- If `layoutMode` is not provided, the component defaults to the new responsive behavior.

These changes address the issue of adapting the playback screen layout for smaller devices and provide a foundation for more dynamic layout control.